### PR TITLE
Fix: VIP are now only scheduled to CP nodes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ docker run ghcr.io/kube-vip/kube-vip manifest daemonset \
         --interface <NIC on Host - e.g. ens18> 
         --address <VIP IP - e.g. 10.3.2.1>
         --controlplane 
+        --taint
         --leaderElection 
         --inCluster
 ```

--- a/templates/kube-vip.yml.j2
+++ b/templates/kube-vip.yml.j2
@@ -7,13 +7,23 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: kube-vip-ds
+      app.kubernetes.io/name: kube-vip-ds
   template:
     metadata:
       creationTimestamp: null
       labels:
-        name: kube-vip-ds
+        app.kubernetes.io/name: kube-vip-ds
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       containers:
       - args:
         - manager
@@ -54,6 +64,11 @@ spec:
             - SYS_TIME
       hostNetwork: true
       serviceAccountName: kube-vip
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
   updateStrategy: {}
 status:
   currentNumberScheduled: 0


### PR DESCRIPTION
The CP VIP is now only scheduled to control plane nodes. The `--taint` flag was not set while creating the kube-vip manifest. 