### PR TITLE
`Development`: Add variable for architecture for calicoctl

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ cni_plugin: calico
 # If Calico is defined as CNI - install calicoctl on nodes
 install_calicoctl: true
 calicoctl_version: "v3.29.1"
-calicoctl_host_architecture: "{% if ansible_facts.ansible_architecture == 'x86_64' %}amd64{% else %}arm64{% endif %}"
+calicoctl_host_architecture: "{% if ansible_architecture == 'x86_64' %}amd64{% else %}arm64{% endif %}"
 
 #####################################################################
 # Cluster Network Configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ cni_plugin: calico
 # If Calico is defined as CNI - install calicoctl on nodes
 install_calicoctl: true
 calicoctl_version: "v3.29.1"
+calicoctl_host_architecture: "{% if ansible_facts.ansible_architecture == 'x86_64' %}amd64{% else %}arm64{% endif %}"
 
 #####################################################################
 # Cluster Network Configuration

--- a/tasks/install-calicoctl.yml
+++ b/tasks/install-calicoctl.yml
@@ -3,7 +3,7 @@
 - name: Download and install calicoctl 
   become: true
   get_url:
-    url: "https://github.com/projectcalico/calico/releases/download/{{ calicoctl_version }}/calicoctl-linux-arm64"
+    url: "https://github.com/projectcalico/calico/releases/download/{{ calicoctl_version }}/calicoctl-linux-{{ calicoctl_host_architecture }}"
     dest: /usr/local/bin/calicoctl
     force: true
     mode: "+rx"


### PR DESCRIPTION
Until now, the role always installed the `arm64` version of `calicoctl`.
On non arm hosts, this leads to this error message: `exec: Failed to execute process: '/usr/local/bin/calicoctl' the file could not be run by the operating system.`

This PR adds new variable `calicoctl_host_architecture` for this condition. By default, the variable is either `amd64` on `x86_64` or `arm64` on all others. While this does not represents _all_ architectures and the if condition is quite generic, we still believe that this is sufficient for _most_ cases (and the few edge cases are not proportional to the otherwise way more complex condition).
